### PR TITLE
Multi site support - YouTube Chat Embed, YouTube.com

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,11 @@ const CONFIG = {
     // Chat Options
     enableChatColors: true,
     separateChatLines: false,
+
+    // Site Options
+    enableYoutubeGaming: true,
+    enableYoutubeVanilla: true,
+    enableYoutubeEmbed: true,
     
     // Ice Options (Ice_Poseidon)
     enableOldIceEmotes: false,

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -3,6 +3,10 @@ import ChatScroller from './ChatScroller';
 import ChatWatcher from './ChatWatcher';
 import RouteWatcher from './RouteWatcher';
 
+import {
+  isLivestream, isYoutubeGaming,
+  isYoutubeEmbed, isYoutubeVanilla
+} from 'src/helpers/Identification';
 import PersistentSyncStorage from 'src/helpers/PersistentSyncStorage';
 
 
@@ -28,7 +32,20 @@ class Main {
   }
 
   onRouteChange() {
-    if(this.isLivestream()) {
+    const {
+      enableYoutubeGaming,
+      enableYoutubeVanilla,
+      enableYoutubeEmbed
+    } = PersistentSyncStorage.data.options;
+
+    if(
+      isLivestream() &&
+      (
+        (isYoutubeGaming() && enableYoutubeGaming) ||
+        (isYoutubeVanilla() && enableYoutubeVanilla) ||
+        (isYoutubeEmbed() && enableYoutubeEmbed)
+      )
+    ) {
       this.init();
     }
     // setTimeout(() => {
@@ -41,17 +58,6 @@ class Main {
     
     this.chatScroller = new ChatScroller;
     this.chatScroller.init();
-  }
-
-  isLivestream() {
-    const timeDisplay = document.querySelector('.ytp-time-display');
-    const chatApp = document.querySelector('yt-live-chat-app');
-    const chatHeader = document.querySelector('.yt-live-chat-renderer-0');
-  
-    const timeDisplayCheck = timeDisplay && timeDisplay.classList.contains('ytp-live');
-    const chatCheck = (document.body.contains(chatApp) || document.body.contains(chatHeader));
-
-    return (timeDisplayCheck || chatCheck);
   }
 }
 

--- a/src/helpers/Identification.js
+++ b/src/helpers/Identification.js
@@ -1,0 +1,30 @@
+export const isLivestream = () => {
+    const timeDisplay = document.querySelector('.ytp-time-display');
+    const chatApp = document.querySelector('yt-live-chat-app');
+    const chatHeader = document.querySelector('.yt-live-chat-renderer-0');
+    
+    const timeDisplayCheck = timeDisplay && timeDisplay.classList.contains('ytp-live');
+    const chatCheck = (document.body.contains(chatApp) || document.body.contains(chatHeader));
+
+    return (timeDisplayCheck || chatCheck);
+}
+
+// isYoutubeGaming checks for the presence of ytg-app, the top level element for YT Gaming
+export const isYoutubeGaming = () => {
+    return !!document.querySelector('ytg-app');
+}
+
+// isYoutubeEmbed checks that this is an iframe, and it is **not** loaded from youtube.com (main site uses embed too)
+export const isYoutubeEmbed = () => {
+    // If the frameElement is available, then CORS means that we must be on youtube.com.
+    if (window.frameElement) return false;
+
+    // If the window location isn't the parent location, then we are in an iframe.
+    return (window.location != window.parent.location);
+}
+
+// isYoutubeEmbed checks that this is an iframe, and it is being used on youtube.com
+export const isYoutubeVanilla = () => {
+    // window.frameElement is only available from youtube.com sites from within iframe per CORS
+    return !!window.frameElement;
+}

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -28,6 +28,30 @@
     <div class="hr"></div>
     
     <div class="section">
+      <h3 class="options-heading">Site Options</h3>
+      <div class="options-description">Choose what sites you want BetterYTG enabled on</div>
+
+      <div class="options-table">
+        <div class="option-row">
+          <div class="option-cell"><label for="enableYoutubeGaming">Enable BetterYTG on Youtube Gaming</label></div>
+          <div class="option-cell"><input disabled type="checkbox" id="enableYoutubeGaming" class="option-input"></div>
+        </div>
+
+        <div class="option-row">
+          <div class="option-cell"><label for="enableYoutubeVanilla">Enable BetterYTG on Youtube Vanilla (youtube.com)</label></div>
+          <div class="option-cell"><input disabled type="checkbox" id="enableYoutubeVanilla" class="option-input"></div>
+        </div>
+
+        <div class="option-row">
+          <div class="option-cell"><label for="enableYoutubeEmbed">Enable BetterYTG on Youtube Chat Embeds</label></div>
+          <div class="option-cell"><input disabled type="checkbox" id="enableYoutubeEmbed" class="option-input"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="hr"></div>
+
+    <div class="section">
       <h3 class="options-heading">Chat Options</h3>
       <div class="options-description"></div>
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,7 +41,8 @@
         "*://*.youtube.com/*"
       ],
       "run_at": "document_end",
-      "js": [ "content.js" ]
+      "js": [ "content.js" ],
+      "all_frames": true
     }
   ],
 


### PR DESCRIPTION
This PR adds support for the extension to work on YouTube's normal site and YouTube chat embeds. The main motivation behind this PR is to get the extension to work with the embedded chat on IcePoseidon.com. 

Since the name of the extension is BetterYTG, some users may not want to to affect their normal YouTube experience, therefore this pull request also includes added options to the options menu so users can decide what sites to enable the extension on. Below are the new setting keys as well as their defaults.

```json
    // Site Options
    enableYoutubeGaming: true,
    enableYoutubeVanilla: true,
    enableYoutubeEmbed: true,
```

These options have been added to the options pane under their own header, `Site Options`. This has been tested across iframes, YTG as well as normal YouTube.

**Unfortunately, this will require a permissions update**, since the manifest has been updated with `"all_frames": true`, meaning that all frames that match the content script matches list will have the extension loaded. This was the only way to enable support on YouTube.com (which internally uses embeds) and YouTube chat embeds.

![Settings](https://user-images.githubusercontent.com/6655339/42978342-51ed8f60-8bc4-11e8-9c53-047e7e6bcdf6.png)
